### PR TITLE
fix: use host low-level channel dispatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### 修复 / Fixed
 
-- ⏸️ **消息中断与并发队列 ([#653](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/653))** — 将会话队列和 interrupt 语义交给 OpenClaw Host，避免暂停/中断消息被 Connector 队列阻塞；并发回调期间持续保持连接心跳。
-  **Interrupt and concurrent queue ownership** — delegates session queue and interrupt semantics to the OpenClaw host so pause/interrupt messages are not blocked by a connector queue, while keeping the connection heartbeat active until every concurrent callback settles.
+- ⏸️ **消息中断与并发队列 ([#653](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/653))** — 将会话队列和 interrupt 语义交给 OpenClaw Host，并显式使用 Host 注入的低层 Channel 派发入口，避免暂停/中断消息被 Connector 队列或旧回合阻塞；并发回调期间持续保持连接心跳。
+  **Interrupt and concurrent queue ownership** — delegates session queue and interrupt semantics to the OpenClaw host and explicitly uses the host-injected low-level channel dispatcher, so pause/interrupt messages are not blocked by a connector queue or an active older turn, while keeping the connection heartbeat active until every concurrent callback settles.
 
 ## [0.8.25] - 2026-08-20
 

--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -1472,12 +1472,10 @@ async function handleDingTalkMessageInternal(
       ctx: { ...ctxPayload, BodyForAgent: finalContent },
       cfg,
       dispatcherOptions,
-      // Queue ownership belongs to OpenClaw. In particular, interrupt mode must let a newer
-      // inbound reach core while the previous tool/model run is still active.
-      replyOptions: {
-        ...replyOptions,
-        allowActiveQueueResolution: true,
-      },
+      // 使用 Host 注入的低层 Channel 派发入口。该入口在 OpenClaw 2026.8.1
+      // 会启用 active queue resolution，使 interrupt 能越过仍在执行的旧回合。
+      dispatchReplyFromConfig: core.channel.reply.dispatchReplyFromConfig,
+      replyOptions,
     });
 
     const { queuedFinal, counts } = dispatchResult;

--- a/src/sdk/helpers.ts
+++ b/src/sdk/helpers.ts
@@ -5,7 +5,7 @@
  */
 
 import type { SecretInput, SecretInputRef } from "./types.ts";
-import { isValidSecretRef } from "openclaw/plugin-sdk/secret-input";
+import { isSecretRef, isValidSecretRef } from "openclaw/plugin-sdk/secret-input";
 
 // ============================================================================
 // 账号 ID 处理
@@ -40,7 +40,7 @@ export function normalizeAccountId(accountId: string): string {
  * 判断是否为 SecretInput 引用
  */
 export function isSecretInputRef(value: unknown): value is SecretInputRef {
-  return isValidSecretRef(value);
+  return isSecretRef(value) && isValidSecretRef(value);
 }
 
 /**

--- a/tests/core/message-handler-policy.test.ts
+++ b/tests/core/message-handler-policy.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockSendProactive = vi.hoisted(() => vi.fn(async () => undefined));
 const mockDispatchReply = vi.hoisted(() => vi.fn(async () => ({ queuedFinal: false, counts: { final: 0 } })));
+const mockLowLevelDispatch = vi.hoisted(() => vi.fn());
 
 vi.mock("../../src/utils/utils-legacy.ts", async () => ({
   ...(await import("../../src/utils/session.ts")),
@@ -50,6 +51,7 @@ vi.mock("../../src/runtime.ts", async () => {
           resolveEnvelopeFormatOptions: vi.fn(() => ({})),
           formatAgentEnvelope: vi.fn(() => "body"),
           dispatchReplyWithBufferedBlockDispatcher: mockDispatchReply,
+          dispatchReplyFromConfig: mockLowLevelDispatch,
         },
         routing,
       },
@@ -200,7 +202,7 @@ describe("handleDingTalkMessage policy guards", () => {
       await vi.waitFor(() => expect(mockDispatchReply).toHaveBeenCalledTimes(2));
       expect(
         mockDispatchReply.mock.calls.every(
-          ([request]) => request.replyOptions.allowActiveQueueResolution === true,
+          ([request]) => request.dispatchReplyFromConfig === mockLowLevelDispatch,
         ),
       ).toBe(true);
     } finally {

--- a/tests/core/message-handler-routing.test.ts
+++ b/tests/core/message-handler-routing.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const state = vi.hoisted(() => ({
   dispatch: vi.fn(),
+  lowLevelDispatch: vi.fn(),
   workspace: vi.fn((_cfg: unknown, id: string) => `/workspaces/${id}`),
   send: vi.fn(async () => undefined),
   recall: vi.fn(async () => undefined),
@@ -41,6 +42,7 @@ vi.mock("../../src/runtime.ts", async () => {
         formatAgentEnvelope: ({ body }: { body: string }) => body,
         finalizeInboundContext: (ctx: unknown) => ctx,
         dispatchReplyWithBufferedBlockDispatcher: state.dispatch,
+        dispatchReplyFromConfig: state.lowLevelDispatch,
       },
     },
   }) };
@@ -93,6 +95,7 @@ describe("DingTalk host-owned routing", () => {
     await handleDingTalkMessage(message());
     await processed(1);
     expect(state.workspace).toHaveBeenCalledWith(expect.anything(), "support");
+    expect(state.dispatch.mock.calls[0][0].dispatchReplyFromConfig).toBe(state.lowLevelDispatch);
     expect(state.dispatch.mock.calls[0][0].ctx).toMatchObject({
       SessionKey: "agent:support:dingtalk-connector:group:group-1", AccountId: "TeamBot",
     });


### PR DESCRIPTION
## 目标 / Goal

修复 OpenClaw 2 发布门禁发现的两个适配问题：Connector 将 `allowActiveQueueResolution` 放进了 `replyOptions`，稳定版 Host 会忽略它；同时 SecretRef 校验直接把 `unknown` 传给非类型守卫函数，新增了 TypeScript 回归。

Fix two OpenClaw 2 release-gate findings: the connector placed `allowActiveQueueResolution` inside `replyOptions`, where the stable host ignores it, and SecretRef validation passed `unknown` directly to a non-type-guard API.

## 实现 / Implementation

- 将 Host 注入的 `core.channel.reply.dispatchReplyFromConfig` 显式传给缓冲 dispatcher。OpenClaw 2026.8.1 为该低层 Channel 入口启用 active queue resolution，从而让 interrupt 越过仍在执行的旧回合。
- 先用 SDK `isSecretRef` 收窄，再调用 `isValidSecretRef`。
- 更新并发/路由回归，验证每次派发都使用 Host 注入的低层入口。

## 验证 / Verification

- OpenClaw 2026.8.1 / Node 26.4.0：`npm run build` 通过。
- 路由、策略、连接、SecretRef 专项测试全部通过。
- 全量测试：535 通过、11 跳过；仅保留与基线一致的 5 个 `probe` 失败。
- `npm run type-check` 从 23 个错误恢复为 21 个既有基线错误；本次新增的两个类型错误已消除。
- `git diff --check` 通过。

## 风险与回滚 / Risk and rollback

变更只选择 Host 已公开注入的低层派发函数，不改变消息内容或 SessionKey。若出现回归，可回退本提交，恢复普通 Host 派发路径，但 interrupt 将再次可能等待旧回合。
