### PR TITLE
release: v0.8.26-beta.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.26-beta.0] - 2026-09-02
+
+> **社区验证版本** — 完成钉钉 Connector 对 OpenClaw 2.0 稳定版运行时的 SDK、密钥契约、Host 队列/中断与 Agent 路由适配。该版本发布到 npm `beta` 标签，不会替换稳定用户使用的 `latest`（`0.8.25`）。详见 [Release Notes](docs/RELEASE_NOTES_V0.8.26-beta.0.md)。
+> **Community validation release** — adapts the DingTalk Connector to the stable OpenClaw 2.0 runtime, including the SDK, secret contract, host-owned queue/interrupt semantics, and agent routing. It is published under npm's `beta` tag and does not replace the stable `latest` (`0.8.25`).
+
 ### 变更 / Changed
 
 - 🔄 **OpenClaw 2 运行时适配 ([#656](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/656))** — 迁移到当前 Plugin SDK、Host 配置快照、缓冲回复调度器和 Channel Secret Contract；最低宿主版本为 OpenClaw `2026.8.1`。
@@ -18,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - ⏸️ **消息中断与并发队列 ([#653](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/653))** — 将会话队列和 interrupt 语义交给 OpenClaw Host，避免暂停/中断消息被 Connector 队列阻塞；并发回调期间持续保持连接心跳。
   **Interrupt and concurrent queue ownership** — delegates session queue and interrupt semantics to the OpenClaw host so pause/interrupt messages are not blocked by a connector queue, while keeping the connection heartbeat active until every concurrent callback settles.
+
+### 升级 / Upgrade
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.26-beta.0
+openclaw gateway restart
+```
 
 ## [0.8.25] - 2026-08-20
 

--- a/docs/RELEASE_NOTES_V0.8.26-beta.0.md
+++ b/docs/RELEASE_NOTES_V0.8.26-beta.0.md
@@ -15,6 +15,7 @@
 
 - 移除 Connector 自己的会话队列，由 OpenClaw Host 统一处理排队和 interrupt。
 - 暂停、中断等控制消息不再被 Connector 队列阻塞。
+- 显式使用 Host 注入的低层 Channel 派发入口，确保 active queue resolution 在稳定版运行时真正生效（[#660](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/660)）。
 - 并发消息处理期间保持 DingTalk Stream 连接生命周期。
 
 ### Host Agent 路由 ([#657](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/657))
@@ -30,7 +31,7 @@
 - 插件成功注册 DingTalk Channel 与 15 个 Gateway Methods，兼容性和诊断结果为空。
 - 路由、策略、连接专项测试 26/26 通过；全量测试 535 通过、11 跳过。
 - 5 个 `probe` 单测失败与合入前基线一致，本版本没有新增失败。
-- 使用测试组织凭据完成 access-token 探测、DingTalk Stream 启动及主动消息发送；发布前以新的钉钉回复完成入站与自动回复闭环验证。
+- 使用测试组织凭据完成 access-token 探测、DingTalk Stream 启动、主动消息发送，以及 `openclaw2-final-ping` → `openclaw2-final-pong` 的真实入站、Host Agent 派发和钉钉回包闭环验证。
 
 ## 安装与反馈 / Install and feedback
 
@@ -50,4 +51,5 @@ openclaw gateway restart
 - [PR #656](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/656)
 - [PR #653](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/653)
 - [PR #657](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/657)
+- [PR #660](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/660)
 - [完整变更日志 / Full changelog](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)

--- a/docs/RELEASE_NOTES_V0.8.26-beta.0.md
+++ b/docs/RELEASE_NOTES_V0.8.26-beta.0.md
@@ -1,0 +1,53 @@
+# Release Notes - v0.8.26-beta.0
+
+> **社区验证版本** — 本版本完成钉钉 Connector 对 OpenClaw 2.0 稳定版的适配，发布到 npm `beta` 标签，不会改变 `latest`（仍为 `0.8.25`）。
+> **Community validation release** — This release adapts the DingTalk Connector to the stable OpenClaw 2.0 runtime. It is published under npm's `beta` tag and does not change `latest` (which remains `0.8.25`).
+
+## 主要变化 / Highlights
+
+### OpenClaw 2 Plugin SDK 与密钥契约 ([#656](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/656))
+
+- 迁移到当前 Plugin SDK 与 Host 配置快照。
+- 使用缓冲回复调度器和 Channel Secret Contract，兼容 OpenClaw 2 的 `SecretRef`。
+- 最低宿主版本调整为 OpenClaw `2026.8.1`。
+
+### Host 队列与 interrupt ([#653](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/653))
+
+- 移除 Connector 自己的会话队列，由 OpenClaw Host 统一处理排队和 interrupt。
+- 暂停、中断等控制消息不再被 Connector 队列阻塞。
+- 并发消息处理期间保持 DingTalk Stream 连接生命周期。
+
+### Host Agent 路由 ([#657](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/657))
+
+- 消息准入后通过 OpenClaw `resolveAgentRoute` 解析一次 Agent。
+- 将最终 Agent、workspace 与 SessionKey 一致地传递到派发路径。
+- 多 Agent 配置不再错误回退到硬编码的 `main`。
+- 保留钉钉账号大小写、群聊发送者隔离与共享记忆等既有 Session 投影语义。
+
+## 验证 / Verification
+
+- 在 OpenClaw `2026.8.1` 上完成构建、插件加载和真实 npm 打包安装验证。
+- 插件成功注册 DingTalk Channel 与 15 个 Gateway Methods，兼容性和诊断结果为空。
+- 路由、策略、连接专项测试 26/26 通过；全量测试 535 通过、11 跳过。
+- 5 个 `probe` 单测失败与合入前基线一致，本版本没有新增失败。
+- 使用测试组织凭据完成 access-token 探测、DingTalk Stream 启动及主动消息发送；发布前以新的钉钉回复完成入站与自动回复闭环验证。
+
+## 安装与反馈 / Install and feedback
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.26-beta.0
+openclaw gateway restart
+```
+
+遇到问题请在 [Issues](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues) 报告，并附上 Connector、OpenClaw 版本及脱敏日志。
+
+## 后续节奏 / Next steps
+
+观察 beta 的 Stream、AI Card、interrupt 和多 Agent 路由表现；没有阻塞回归后，再以相同功能集晋升为 `0.8.26` 正式版。
+
+## 相关链接 / Related links
+
+- [PR #656](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/656)
+- [PR #653](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/653)
+- [PR #657](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/657)
+- [完整变更日志 / Full changelog](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/blob/main/CHANGELOG.md)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.25",
+  "version": "0.8.26-beta.0",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.25",
+  "version": "0.8.26-beta.0",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## 发布内容

发布 OpenClaw 2.0 钉钉 Connector 适配为 npm beta，包含：

- #656：当前 Plugin SDK、Host 配置快照、SecretRef 与 Channel Secret Contract。
- #653 / #660：Host-owned queue / interrupt，以及稳定版低层 Channel 派发入口。
- #657：Host Agent Routing 与 DingTalk Session 投影。

## 版本与渠道

- npm 包：`@dingtalk-real-ai/dingtalk-connector@0.8.26-beta.0`
- npm 标签：`beta`
- `latest` 保持 `0.8.25`，不影响稳定用户。
- 最低宿主版本：OpenClaw `2026.8.1`

## 验证

- Node 26.4.0 / OpenClaw 2026.8.1：`npm run build` 通过。
- 路由、策略、连接、SecretRef 专项测试：52/52 通过。
- 全量测试：535 通过、11 跳过；仅保留与合入前一致的 5 个 `probe` 基线失败。
- TypeScript：2 个本次新增错误已由 #660 消除；仍保留 21 个仓库既有基线诊断，未隐藏。
- npm dry-run：`0.8.26-beta.0`，163 files，约 422 KB，清单与版本正确。
- 真实测试组织：access-token probe 通过，DingTalk Stream 启动成功，主动出站成功；`openclaw2-final-ping` 入站后经过 Host Agent 派发，并收到 `openclaw2-final-pong` 回包。
- `git diff --check origin/main...HEAD` 通过。

## 风险与回滚

- 先发布 `beta`，不移动 `latest`。
- 若发现阻塞问题，停止 beta 推广；npm 已发布版本不覆盖，使用新的 beta 修复版本。
- 当前本机已在相同 OpenClaw 2026.8.1 Host 上运行该精确源码构建，可继续观察 Stream、AI Card、interrupt 与多 Agent 行为。

Refs #653 #656 #657 #660
