### PR TITLE
fix: make OpenClaw 2 runtime loading Windows-safe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### 修复 / Fixed
+
+- 🪟 **Windows OpenClaw 2 插件加载与 Runtime 共享 ([#662](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/662))** — 插件入口改用 Host 注入的 `api.source` 记录重复加载来源，避免 Windows jiti CJS 转换路径解析 `import.meta` 失败；Runtime Store 改为以 `dingtalk-connector` 为键的全局共享槽，确保 cache-busted 模块实例读取到同一份 Host Runtime。真实 OpenClaw 路由回归同时确认：仅配置一个 Agent 时无需额外添加 binding。
+  **Windows OpenClaw 2 plugin loading and shared runtime** — Uses the host-provided `api.source` for duplicate-load tracking so the Windows jiti CJS transform path never has to parse `import.meta`; switches the runtime store to a globally shared `dingtalk-connector` slot so cache-busted module instances read the same host runtime. A real OpenClaw routing regression test also confirms that a sole configured agent does not require an explicit binding.
+
 ## [0.8.26-beta.0] - 2026-09-02
 
 > **社区验证版本** — 完成钉钉 Connector 对 OpenClaw 2.0 稳定版运行时的 SDK、密钥契约、Host 队列/中断与 Agent 路由适配。该版本发布到 npm `beta` 标签，不会替换稳定用户使用的 `latest`（`0.8.25`）。详见 [Release Notes](docs/RELEASE_NOTES_V0.8.26-beta.0.md)。

--- a/index.ts
+++ b/index.ts
@@ -32,7 +32,7 @@ export { registerGatewayMethods } from "./src/gateway-methods.ts";
  * 表现就是"消息时而能收到，时而收不到 / 回复丢失"。
  *
  * 这里做一个轻量自检：
- * - 把当前 index.mjs 的绝对路径写入全局 Symbol 表
+ * - 把 OpenClaw 注入的当前插件入口路径写入全局 Symbol 表
  * - 同名 plugin id 被第二次注册时打印警告（或在 `DINGTALK_STRICT_DUPLICATE_LOAD=1` 时直接抛错）
  *
  * 作为运行时兜底，建议同时在 `openclaw.json` 只保留一条加载路径。
@@ -46,8 +46,8 @@ function recordAndCheckLoadPath(api: OpenClawPluginApi): void {
     g[DUPLICATE_LOAD_SYMBOL] = store;
 
     const pluginId = "dingtalk-connector";
-    // import.meta.url 在 ESM 下指向当前 index.mjs 路径，正好是我们要比较的维度
-    const here = typeof import.meta !== "undefined" && import.meta?.url ? String(import.meta.url) : "<unknown>";
+    // 使用 Host 注入的入口来源，避免 import.meta 在 Windows jiti CJS 转换路径下触发语法错误。
+    const here = api.source?.trim() || api.rootDir?.trim() || "<unknown>";
     const paths = store.get(pluginId) ?? new Set<string>();
     paths.add(here);
     store.set(pluginId, paths);

--- a/src/runtime.ts
+++ b/src/runtime.ts
@@ -1,6 +1,9 @@
 import { createPluginRuntimeStore, type PluginRuntime } from "openclaw/plugin-sdk/runtime-store";
 
 const { setRuntime: setDingtalkRuntime, getRuntime: getDingtalkRuntime } =
-  createPluginRuntimeStore<PluginRuntime>("DingTalk runtime not initialized");
+  createPluginRuntimeStore<PluginRuntime>({
+    pluginId: "dingtalk-connector",
+    errorMessage: "DingTalk runtime not initialized",
+  });
 
 export { getDingtalkRuntime, setDingtalkRuntime };

--- a/tests/openclaw2-windows-compat.unit.test.ts
+++ b/tests/openclaw2-windows-compat.unit.test.ts
@@ -1,0 +1,40 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { resolveAgentRoute } from "openclaw/plugin-sdk/routing";
+import type { PluginRuntime } from "openclaw/plugin-sdk/core";
+import { describe, expect, it } from "vitest";
+
+describe("OpenClaw 2 Windows loader compatibility", () => {
+  it("shares the injected runtime across cache-busted module instances", async () => {
+    const first = await import("../src/runtime.ts?instance=first");
+    const second = await import("../src/runtime.ts?instance=second");
+    const runtime = { marker: "shared-runtime" } as unknown as PluginRuntime;
+
+    first.setDingtalkRuntime(runtime);
+
+    expect(second.getDingtalkRuntime()).toBe(runtime);
+  });
+
+  it("keeps the plugin entry source free of executable import.meta", () => {
+    const entrySource = readFileSync(join(process.cwd(), "index.ts"), "utf8");
+    const executableSource = entrySource
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/\/\/.*$/gm, "");
+
+    expect(executableSource).not.toContain("import.meta");
+  });
+});
+
+describe("OpenClaw 2 single-agent routing compatibility", () => {
+  it("routes a sole main agent without requiring an explicit binding", () => {
+    const route = resolveAgentRoute({
+      cfg: { agents: { entries: { main: {} } } },
+      channel: "dingtalk-connector",
+      accountId: "default",
+      peer: { kind: "direct", id: "user-1" },
+    });
+
+    expect(route).toMatchObject({ agentId: "main", matchedBy: "default" });
+  });
+});


### PR DESCRIPTION
## Summary

Fixes #662 for OpenClaw 2026.8.1 on Windows by addressing the two loader/runtime failures reported against `0.8.26-beta.0`:

- use the plugin source injected by the host (`api.source`, falling back to `api.rootDir`) for duplicate-load tracking, so the plugin entry no longer executes `import.meta` on the Windows jiti CJS transform path;
- use the object form of `createPluginRuntimeStore` with `pluginId: "dingtalk-connector"`, so cache-busted module instances share the same runtime slot through `globalThis`;
- add regressions for cache-busted runtime sharing, executable `import.meta` in the entry source, and OpenClaw's real single-agent fallback routing.

The routing regression also shows that a sole configured `main` agent resolves via `matchedBy: "default"` without an explicit DingTalk binding. A binding may still be useful for multi-agent selection, but it is not required for the single-agent setup described in #662.

## Verification

Base: `0ccfba47e62dbb3078d066207de26a3df67019cc` (`v0.8.26-beta.0`)

### Red / green regression

Before the fix, the new compatibility suite had 2 failures out of 3:

- cache-busted module instance threw `DingTalk runtime not initialized`;
- the plugin entry contained executable `import.meta`;
- sole-main-agent routing already passed.

After the fix:

```text
tests/openclaw2-windows-compat.unit.test.ts: 3 passed
```

### Focused tests

```text
4 test files passed
33 tests passed
```

The focused run covers the new Windows/OpenClaw 2 compatibility suite, message-handler routing, message policy, and channel registration.

### Build and package inspection

- `npm run build`: passed
- `git diff --check`: passed
- built `dist/index.mjs`: no `import.meta`
- packed tarball SHA-256: `c13c9b46e2a8ab3d5c65014fccebbeb50881d41fe20514da0e7f0b8a30605467`
- isolated install with Node `22.22.3` and OpenClaw `2026.8.1`: plugin status `loaded`, enabled, channel registered, no compatibility or plugin diagnostics

### Full-suite comparison

Candidate:

```text
45 passed files, 1 failed
538 passed tests, 11 skipped, 5 failed
```

Exact base with the same dependency tree:

```text
44 passed files, 1 failed
535 passed tests, 11 skipped, 5 failed
```

The five failures are identical pre-existing `tests/probe/probe.test.ts` fetch-mock failures. Typecheck also reports the same 21 existing diagnostics on candidate and exact base (`toSorted` lib target, private `DWClient.socket`, and missing `pdf-parse` types), with no new diagnostic introduced by this PR.

## Remaining validation

I do not have a Windows runner, so the exact Windows 10 + jiti path still needs reporter confirmation before release. The package has been exercised with the reporter's Node major/minor and exact OpenClaw version in an isolated installation, and the two reported failures now have deterministic regressions.

## Risk and rollback

The changes are limited to plugin load-path diagnostics and runtime-store identity. Reverting this commit restores the previous behavior; no configuration or secret migration is involved.
