### PR TITLE
release: v0.8.26-beta.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.26-beta.1] - 2026-09-03
+
+> **Windows 兼容性验证版本** — 修复 OpenClaw `2026.8.1` 在 Windows jiti 加载路径中的插件入口解析和跨模块 Runtime 共享问题。本版本发布到 npm `beta` 标签，不会替换稳定用户使用的 `latest`（`0.8.25`）。详见 [Release Notes](docs/RELEASE_NOTES_V0.8.26-beta.1.md)。
+> **Windows compatibility validation release** — fixes plugin-entry parsing and cross-module runtime sharing on the Windows jiti loader path in OpenClaw `2026.8.1`. It is published under npm's `beta` tag and does not replace the stable `latest` (`0.8.25`).
+
 ### 修复 / Fixed
 
 - 🪟 **Windows OpenClaw 2 插件加载与 Runtime 共享 ([#662](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/662))** — 插件入口改用 Host 注入的 `api.source` 记录重复加载来源，避免 Windows jiti CJS 转换路径解析 `import.meta` 失败；Runtime Store 改为以 `dingtalk-connector` 为键的全局共享槽，确保 cache-busted 模块实例读取到同一份 Host Runtime。真实 OpenClaw 路由回归同时确认：仅配置一个 Agent 时无需额外添加 binding。
   **Windows OpenClaw 2 plugin loading and shared runtime** — Uses the host-provided `api.source` for duplicate-load tracking so the Windows jiti CJS transform path never has to parse `import.meta`; switches the runtime store to a globally shared `dingtalk-connector` slot so cache-busted module instances read the same host runtime. A real OpenClaw routing regression test also confirms that a sole configured agent does not require an explicit binding.
+
+### 升级 / Upgrade
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.26-beta.1 --force --accept-capabilities
+openclaw gateway restart
+```
 
 ## [0.8.26-beta.0] - 2026-09-02
 

--- a/docs/RELEASE_NOTES_V0.8.26-beta.1.md
+++ b/docs/RELEASE_NOTES_V0.8.26-beta.1.md
@@ -1,0 +1,51 @@
+# Release Notes - v0.8.26-beta.1
+
+> **Windows 兼容性验证版本** — 本版本修复 OpenClaw `2026.8.1` 在 Windows jiti 加载路径中的插件入口解析和 Runtime 共享问题，发布到 npm `beta` 标签，不会改变 `latest`（仍为 `0.8.25`）。
+> **Windows compatibility validation release** — This release fixes plugin-entry parsing and runtime sharing on the Windows jiti loader path in OpenClaw `2026.8.1`. It is published under npm's `beta` tag and does not change `latest` (which remains `0.8.25`).
+
+## 修复 / Fixes
+
+### Windows 插件入口加载 ([#662](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/662) / [#664](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/664))
+
+- 重复加载检测改用 OpenClaw Host 注入的 `api.source`，并以 `api.rootDir` 兜底。
+- 插件入口不再执行 `import.meta`，避免 Windows jiti CJS 转换路径抛出 `Cannot use 'import.meta' outside a module`。
+
+### 跨模块 Runtime 共享
+
+- Runtime Store 改用带 `pluginId: "dingtalk-connector"` 的全局共享槽。
+- cache-busted 模块实例现在能够读取 `register()` 注入的同一份 Host Runtime，不再错误抛出 `DingTalk runtime not initialized`。
+
+### 单 Agent 路由说明
+
+- 使用 OpenClaw `2026.8.1` 的真实 `resolveAgentRoute` 验证：仅配置 `agents.entries.main` 时，会通过默认路由命中 `main`，无需额外添加 DingTalk binding。
+- 多 Agent 场景仍可使用 binding 显式选择 Agent。
+
+## 验证 / Verification
+
+- 新增兼容性回归在修复前复现 2 个失败，修复后 3/3 通过。
+- 路由、策略、Channel 与 Windows 兼容性专项测试 33/33 通过。
+- 构建通过，发布入口 `dist/index.mjs` 不含 `import.meta`。
+- 全量测试 538 通过、11 跳过；5 个 `probe` 失败与精确合入前基线一致，没有新增失败。
+- TypeScript 诊断与精确基线均为 21 个，没有新增诊断。
+- 使用 Node `22.22.3` 与 OpenClaw `2026.8.1` 完成隔离打包安装；插件成功加载并注册 Channel，兼容性和诊断结果为空。
+- Windows 10 的真实 jiti 链路仍等待 Issue 报告者确认，因此本版本继续使用 `beta` 标签。
+
+## 安装与反馈 / Install and feedback
+
+```bash
+openclaw plugins install @dingtalk-real-ai/dingtalk-connector@0.8.26-beta.1 --force --accept-capabilities
+openclaw gateway restart
+```
+
+遇到问题请在 [#662](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/662) 回复 Connector、OpenClaw 和 Node 版本，并附上脱敏日志。
+
+## 后续节奏 / Next steps
+
+等待 Windows 社区验证插件加载和真实消息闭环；确认没有阻塞回归后，再评估晋升为 `0.8.26` 正式版。
+
+## 相关链接 / Related links
+
+- [Issue #662](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/issues/662)
+- [PR #664](https://github.com/DingTalk-Real-AI/dingtalk-openclaw-connector/pull/664)
+- [v0.8.26-beta.0 Release Notes](RELEASE_NOTES_V0.8.26-beta.0.md)
+- [完整变更日志 / Full changelog](../CHANGELOG.md)

--- a/openclaw.plugin.json
+++ b/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "id": "dingtalk-connector",
   "name": "DingTalk Channel",
-  "version": "0.8.26-beta.0",
+  "version": "0.8.26-beta.1",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "author": "DingTalk Real Team",
   "main": "index.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dingtalk-real-ai/dingtalk-connector",
-  "version": "0.8.26-beta.0",
+  "version": "0.8.26-beta.1",
   "description": "Official OpenClaw DingTalk channel plugin | 钉钉官方 OpenClaw 插件",
   "type": "module",
   "exports": {


### PR DESCRIPTION
## 发布内容

发布 `0.8.26-beta.1`，包含 #664 对 #662 的 Windows OpenClaw 2 兼容性修复：

- 插件入口使用 Host 注入的 `api.source` / `api.rootDir`，避免 Windows jiti CJS 路径解析可执行的 `import.meta`；
- Runtime Store 使用 `pluginId: "dingtalk-connector"` 的全局共享槽，修复 cache-busted 模块实例之间的 `DingTalk runtime not initialized`；
- 明确单 `main` Agent 会由 OpenClaw 默认路由命中，无需额外 binding。

## 版本与渠道

- npm 包：`@dingtalk-real-ai/dingtalk-connector@0.8.26-beta.1`
- npm 标签：`beta`
- `latest` 保持 `0.8.25`，不影响稳定用户。
- 最低宿主版本：OpenClaw `2026.8.1`
- Windows 10 真实 jiti 链路仍等待 #662 报告者确认，因此不晋升正式版。

## 精确版本

- Base：`c92957a1b074aaef1b5abac054a36e44a5ca8803`
- Head：`a4503aa32ed64c2ad280f3be8467b1583d29003d`

## 验证

- `npm run build`：通过。
- Windows/OpenClaw 2、路由、策略与 Channel 专项测试：33/33 通过。
- 完整测试：538 通过、11 跳过；5 个 `probe` mock 失败与精确基线一致，没有新增失败。
- TypeScript：候选与精确基线均为 21 个既有诊断，没有新增诊断。
- `dist/index.mjs`：不含 `import.meta`。
- npm dry-run：版本 `0.8.26-beta.1`，164 files，423,630 bytes，SHA-1 `db2d7a3420bc33892d545a8a4d32c36146030760`。
- `git diff --check`：通过。

## 风险与回滚

- 仅移动 npm `beta` 标签，不移动 `latest`。
- npm 已发布版本不覆盖；若 Windows 社区验证发现阻塞问题，停止推广并以新的 beta 版本修复。
- 本 PR 仅封板版本元数据、CHANGELOG 与 Release Notes；功能代码已通过 #664 合入。

Refs #662 #664
