### PR TITLE
fix: expose inbound DingTalk images to agent via MediaPaths/MediaUrls/MediaTypes

### DIFF
--- a/src/core/message-handler.ts
+++ b/src/core/message-handler.ts
@@ -692,6 +692,15 @@ export async function downloadMediaByCode(
   }
 }
 
+// 根据下载文件的实际扩展名推导 MIME（downloadImageToFile 只产出 jpg/png/gif/webp）
+function imageMimeFromPath(filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  if (ext === '.png') return 'image/png';
+  if (ext === '.gif') return 'image/gif';
+  if (ext === '.webp') return 'image/webp';
+  return 'image/jpeg';
+}
+
 export async function getFileDownloadUrl(
   downloadCode: string,
   fileName: string,
@@ -1428,6 +1437,15 @@ async function handleDingTalkMessageInternal(
       // 当前机器人的加密身份（用于多机器人协作时让上层 Agent 引用 / 互相 @）
       BotChatbotUserId: data.chatbotUserId,
       BotChatbotCorpId: data.chatbotCorpId,
+      // 注入入站图片附件（Fixes #631）：OpenClaw 从 MediaPaths/MediaUrls/MediaTypes
+      // 读取媒体附件，只在 BodyForAgent 里嵌 ![image](file://...) markdown 时
+      // 视觉模型收不到图片数据。SDK resolveMediaFacts 对这三个字段做 Array.isArray
+      // 校验，只接受并行数组，换行拼接的字符串会被静默忽略。
+      ...(imageLocalPaths.length > 0 ? {
+        MediaPaths: imageLocalPaths,
+        MediaUrls: imageLocalPaths,
+        MediaTypes: imageLocalPaths.map(imageMimeFromPath),
+      } : {}),
     };
 
     // 创建 reply dispatcher，使用解析后的 agentId


### PR DESCRIPTION
## Problem

Fixes #631. Images sent from DingTalk never reach the AI: the connector downloads them to local files and embeds `![image](file://...)` markdown in `BodyForAgent`, but OpenClaw resolves media attachments from the dedicated `MediaPaths` / `MediaUrls` / `MediaTypes` context fields — which were never set. Vision models received no image data from the DingTalk channel (dashboard/webchat unaffected).

## Change

`src/core/message-handler.ts`, inbound context construction:

- When `imageLocalPaths` is non-empty, set the three media fields as **parallel string arrays** on `ctxPayload`.
- `MediaTypes` is derived from each downloaded file's actual extension (only `.jpg/.png/.gif/.webp` are produced by `downloadImageToFile`) instead of hardcoding `image/jpeg`.

## Note on the fix sketch in #631

The snippet in the issue used `join("\n")` string values. I verified against the OpenClaw SDK (`resolveMediaFacts` in `media-facts`) that these fields are read with `Array.isArray(...)` and a newline-joined string is **silently ignored** — `MediaPaths?: string[]` per `MediaFactLegacyProjection`. So this PR uses parallel arrays, which is also the positional-alignment format the legacy projection is designed around.

## Verification

- `npx tsc --noEmit`: error count identical to unmodified `main` (21 pre-existing, none in the touched code path; repo `strict: false`).
- `npm run test:all`: 539 passed / 5 failed — the 5 failures are pre-existing on unmodified `main` (`tests/probe/probe.test.ts`), unrelated to this change.
- `npm run build` (tsdown): passes.